### PR TITLE
Fix lint and type errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-hook-form": "^7.58.0"
+        "react-hook-form": "^7.58.0",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -24,6 +25,7 @@
         "@types/node": "^20.19.1",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/uuid": "^10.0.0",
         "eslint": "^9",
         "eslint-config-next": "15.3.3",
         "tailwindcss": "^4",
@@ -1380,6 +1382,13 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
@@ -6352,6 +6361,19 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.58.0"
+    "react-hook-form": "^7.58.0",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -25,6 +26,7 @@
     "@types/node": "^20.19.1",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/uuid": "^10.0.0",
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
     "tailwindcss": "^4",

--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import bcrypt from 'bcrypt';
-import clientPromise from '../../../lib/mongodb';
+import { connectToDB } from '@/lib/mongodb';
 
 const saltRounds = 10;
 
@@ -12,8 +12,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Email and password required' }, { status: 400 });
     }
 
-    const client = await clientPromise;
-    const db = client.db();
+    const db = await connectToDB();
     const users = db.collection('users');
 
     // 1) Check if already registered

--- a/src/app/api/test-db/route.ts
+++ b/src/app/api/test-db/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
-import clientPromise from "../../../lib/mongodb"; // <-- keep the relative path
+import { connectToDB } from "@/lib/mongodb";
 
 // GET /api/test-db
 export async function GET() {
   try {
-    const client = await clientPromise; // waits for the shared connection
-    await client.db().admin().ping(); // lightweight “are you alive?” call
+    const db = await connectToDB();
+    await db.admin().ping(); // lightweight "are you alive?" call
     return NextResponse.json({ status: "connected" });
   } catch (err) {
     console.error("DB connection error:", err);

--- a/src/lib/mongodb.ts
+++ b/src/lib/mongodb.ts
@@ -12,7 +12,6 @@ const client = new MongoClient(uri, options);
 
 // 2️⃣ Cache the connection promise on global (only in dev)
 declare global {
-  // eslint-disable-next-line no-var
   var _mongoClientPromise: Promise<MongoClient>;
 }
 const clientPromise: Promise<MongoClient> =


### PR DESCRIPTION
## Summary
- update MongoDB helpers to use named export
- add uuid dependencies
- remove unused eslint directive
- fix API routes to use connectToDB

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `NEXT_FONT_DOWNLOAD=skip npm run build` *(fails: Failed to fetch font `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6851ab759e988329914da8239ce9265b