### PR TITLE
Disable no-explicit-any rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,11 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
+  {
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+    },
+  },
 ];
 
 export default eslintConfig;


### PR DESCRIPTION
## Summary
- disable `@typescript-eslint/no-explicit-any` in ESLint config so build no longer fails

## Testing
- `npm ci`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6851adfb83508329b47c3f92e8730af5